### PR TITLE
AuthN API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Keratin::AuthN.config.tap do |config|
 
   # The domain of your application
   config.audience = 'myapp.com'
+
+  # HTTP basic auth for using AuthN's private endpoints
+  config.username = 'secret'
+  config.password = 'secret'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,48 @@ Keratin::AuthN.config.tap do |config|
 end
 ```
 
-Use `Keratin::AuthN.subject_from(params[:id_token])` to validate tokens and fetch an `account_id` during signup, login, and session verification.
+### Reading the Session
 
-Send users to `Keratin::AuthN.logout_url(return_to: some_path)` to log them out from the AuthN server.
+Use `Keratin::AuthN.subject_from(params[:authn])` to fetch an `account_id` from the session if and
+only if the session is valid.
+
+### Logging Out
+
+Send users to `Keratin::AuthN.logout_url(return_to: some_path)` to log them out from the AuthN
+server. If you use [keratin/authn-js](https://github.com/keratin/authn-js), you might prefer the
+logout functionality there as it can also take care of deleting the cookie.
+
+### Modifying Accounts
+
+* `Keratin.authn.lock(account_id)`: will lock an account, revoking all sessions (when they time out)
+  and disallowing any new logins. Intended for user moderation actions.
+* `Keratin.authn.unlock(account_id)`: will unlock an account, restoring normal functionality.
+* `Keratin.authn.archive(account_id)`: will wipe all personal information, including username and
+  password. Intended for user deletion routine.
+
+### Example: Sessions
+
+You should store the token in a cookie (the [keratin/authn-js](https://github.com/keratin/authn-js)
+integration can do this automatically) and continue using it to verify a logged-in session:
+
+```ruby
+class ApplicationController
+  private
+
+  def logged_in?
+    !! current_account_id
+  end
+
+  def current_user
+    return @current_user if defined? @current_user
+    @current_user = User.find_by_account_id(current_account_id)
+  end
+
+  def current_account_id
+    Keratin::AuthN.subject_from(cookies[:authn])
+  end
+end
+```
 
 ### Example: Signup
 
@@ -42,7 +81,7 @@ Send users to `Keratin::AuthN.logout_url(return_to: some_path)` to log them out 
 class UsersController
   def create
     @user = User.new(params.require(:user).permit(:name, :email))
-    @user.account_id = Keratin::AuthN.subject_from(params[:user][:id_token])
+    @user.account_id = current_account_id
 
     # ...
   end
@@ -54,28 +93,9 @@ end
 ```ruby
 class SessionsController
   def create
-    @user = User.find_by_account_id(Keratin::AuthN.subject_from(cookies[:id_token]))
+    @user = current_user
 
     # ...
-  end
-end
-```
-
-### Example: Sessions
-
-You should store the token in a cookie and continue using it to verify a logged-in session:
-
-```ruby
-class ApplicationController
-  private
-
-  def logged_in?
-    !! Keratin::AuthN.subject_from(cookies[:id_token])
-  end
-
-  def current_user
-    return @current_user if defined? @current_user
-    @current_user = User.find_by_account_id(Keratin::AuthN.subject_from(cookies[:id_token])
   end
 end
 ```

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "auth/rb"
+require "keratin/authn"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/keratin/authn.rb
+++ b/lib/keratin/authn.rb
@@ -8,7 +8,11 @@ require 'json/jwt'
 
 module Keratin
   def self.authn
-    @authn ||= Issuer.new(Keratin::AuthN.issuer)
+    @authn ||= Issuer.new(
+      Keratin::AuthN.config.issuer,
+      username: Keratin::AuthN.config.username,
+      password: Keratin::AuthN.config.password
+    )
   end
 
   module AuthN
@@ -24,6 +28,12 @@ module Keratin
       # how long (in seconds) to keep keys in the keychain before refreshing.
       # default: 3600
       attr_accessor :keychain_ttl
+
+      # the http basic auth username for accessing private endpoints of the authn issuer.
+      attr_accessor :username
+
+      # the http basic auth password for accessing private endpoints of the authn issuer.
+      attr_accessor :password
     end
 
     def self.config

--- a/lib/keratin/authn.rb
+++ b/lib/keratin/authn.rb
@@ -6,52 +6,51 @@ require_relative 'authn/issuer'
 require 'lru_redux'
 require 'json/jwt'
 
-module Keratin::AuthN
-  class Config
-    # the domain (host) of the main application.
-    # e.g. "audience.tech"
-    attr_accessor :audience
-
-    # the base url of the service handling authentication
-    # e.g. "https://issuer.tech"
-    attr_accessor :issuer
-
-    # the path where we can fetch configuration from our issuer.
-    #
-    # default: "/configuration"
-    attr_accessor :configuration_path
-
-    # how long (in seconds) to keep keys in the keychain before refreshing.
-    # default: 3600
-    attr_accessor :keychain_ttl
+module Keratin
+  def self.authn
+    @authn ||= Issuer.new(Keratin::AuthN.issuer)
   end
 
-  def self.config
-    @config ||= Config.new.tap do |config|
-      config.configuration_path = '/configuration'
-      config.keychain_ttl = 3600
-    end
-  end
+  module AuthN
+    class Config
+      # the domain (host) of the main application.
+      # e.g. "audience.tech"
+      attr_accessor :audience
 
-  def self.keychain
-    @keychain ||= LruRedux::TTL::ThreadSafeCache.new(25, config.keychain_ttl)
-  end
+      # the base url of the service handling authentication
+      # e.g. "https://issuer.tech"
+      attr_accessor :issuer
 
-  class << self
-    # safely fetches a subject from the id token after checking relevant claims and
-    # verifying the signature.
-    #
-    # this may involve HTTP requests to fetch the issuer's configuration and JWKs.
-    def subject_from(id_token)
-      verifier = IDTokenVerifier.new(id_token, keychain)
-      verifier.subject if verifier.verified?
+      # how long (in seconds) to keep keys in the keychain before refreshing.
+      # default: 3600
+      attr_accessor :keychain_ttl
     end
 
-    def logout_url(return_to: nil)
-      query = {redirect_uri: return_to}.to_param if return_to
+    def self.config
+      @config ||= Config.new.tap do |config|
+        config.keychain_ttl = 3600
+      end
+    end
 
-      "#{config.issuer}/sessions/logout#{?? if query}#{query}"
+    def self.keychain
+      @keychain ||= LruRedux::TTL::ThreadSafeCache.new(25, config.keychain_ttl)
+    end
+
+    class << self
+      # safely fetches a subject from the id token after checking relevant claims and
+      # verifying the signature.
+      #
+      # this may involve HTTP requests to fetch the issuer's configuration and JWKs.
+      def subject_from(id_token)
+        verifier = IDTokenVerifier.new(id_token, keychain)
+        verifier.subject if verifier.verified?
+      end
+
+      def logout_url(return_to: nil)
+        query = {redirect_uri: return_to}.to_param if return_to
+
+        "#{config.issuer}/sessions/logout#{?? if query}#{query}"
+      end
     end
   end
-
 end

--- a/lib/keratin/authn.rb
+++ b/lib/keratin/authn.rb
@@ -8,10 +8,9 @@ require 'json/jwt'
 
 module Keratin
   def self.authn
-    @authn ||= Issuer.new(
-      Keratin::AuthN.config.issuer,
-      username: Keratin::AuthN.config.username,
-      password: Keratin::AuthN.config.password
+    @authn ||= AuthN::Issuer.new(AuthN.config.issuer,
+      username: AuthN.config.username,
+      password: AuthN.config.password
     )
   end
 

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -11,7 +11,7 @@ module Keratin::AuthN
     end
 
     def configuration
-      @configuration ||= get(path: Keratin::AuthN.config.configuration_path)
+      @configuration ||= get(path: '/configuration')
     end
 
     def keys

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -3,8 +3,16 @@ require 'net/http'
 
 module Keratin::AuthN
   class Issuer < Keratin::Client
-    def initialize(str)
-      @base = str.chomp('/')
+    def lock(account_id)
+      patch(path: "/accounts/:account_id/lock").result
+    end
+
+    def unlock(account_id)
+      patch(path: "/accounts/:account_id/unlock").result
+    end
+
+    def archive(account_id)
+      delete(path: "/accounts/:account_id").result
     end
 
     def signing_key

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -1,7 +1,8 @@
+require 'keratin/client'
 require 'net/http'
 
 module Keratin::AuthN
-  class Issuer
+  class Issuer < Keratin::Client
     def initialize(str)
       @base = str.chomp('/')
     end
@@ -11,19 +12,13 @@ module Keratin::AuthN
     end
 
     def configuration
-      @configuration ||= get(path: '/configuration')
+      @configuration ||= get(path: '/configuration').data
     end
 
     def keys
       @keys ||= JSON::JWK::Set.new(
-        get(url: configuration['jwks_uri'])
+        get(path: URI.parse(configuration['jwks_uri']).path).data
       )
-    end
-
-    private def get(path: nil, url: nil)
-      uri = URI.parse(url || "#{@base}#{path}")
-
-      JSON.parse(Net::HTTP.get(uri))
     end
   end
 end

--- a/lib/keratin/authn/test/helpers.rb
+++ b/lib/keratin/authn/test/helpers.rb
@@ -26,7 +26,7 @@ module Keratin::AuthN
       # stubs the endpoints necessary to validate a signed JWT
       private def stub_auth_server(issuer: Keratin::AuthN.config.issuer, keypair: jws_keypair)
         Keratin::AuthN.keychain.clear
-        stub_request(:get, "#{issuer}#{Keratin::AuthN.config.configuration_path}").to_return(
+        stub_request(:get, "#{issuer}/configuration").to_return(
           status: 200,
           body: {'jwks_uri' => "#{issuer}/jwks"}.to_json
         )

--- a/lib/keratin/client.rb
+++ b/lib/keratin/client.rb
@@ -15,7 +15,12 @@ module Keratin
     attr_reader :errors
 
     def initialize(errors)
-      @errors = errors
+      @errors = errors.map{|e| [e['field'], e['message']] }
+        .group_by(&:first)
+        .map{|k, v| [k, v.map(&:last)] }
+        .to_h
+
+      super(@errors.inspect)
     end
   end
 

--- a/lib/keratin/client.rb
+++ b/lib/keratin/client.rb
@@ -1,0 +1,73 @@
+module Keratin
+  class Error < StandardError; end
+
+  class ServiceResult
+    attr_reader :data
+    attr_reader :result
+
+    def initialize(data)
+      @data = data
+      @result = data['result']
+    end
+  end
+
+  class ClientError < Keratin::Error
+    attr_reader :errors
+
+    def initialize(errors)
+      @errors = errors
+    end
+  end
+
+  class ServiceError < Keratin::Error
+  end
+
+  class Client
+
+    attr_reader :base
+
+    def initialize(base_url, username: nil, password: nil)
+      @base = base_url.chomp('/')
+      @auth = [username, password] if username && password
+    end
+
+    private def get(**opts)
+      submit(Net::HTTP::Get, **opts)
+    end
+
+    private def patch(**opts)
+      submit(Net::HTTP::Patch, **opts)
+    end
+
+    private def delete(**opts)
+      submit(Net::HTTP::Delete, **opts)
+    end
+
+    private def submit(request_klass, path:)
+      uri = URI.parse("#{base}#{path}")
+
+      request = request_klass.new(uri)
+      request.basic_auth(*@auth) if @auth
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        http.open_timeout = 0.5
+        http.read_timeout = 2.0
+
+        case response = http.request(request)
+        when Net::HTTPSuccess
+          return ServiceResult.new(JSON.parse(response.body))
+        when Net::HTTPRedirection
+          return ServiceResult.new('result' => {
+            'location' => response['Location']
+          })
+        when Net::HTTPClientError
+          raise ClientError.new(JSON.parse(response.body)['errors'])
+        when Net::HTTPServerError
+          raise ServiceError.new(response.body)
+        end
+      end
+    rescue Net::OpenTimeout, Net::ReadTimeout => e
+      raise ServiceError.new(e.message)
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -80,7 +80,8 @@ class Keratin::ClientTest < Keratin::AuthN::TestCase
       begin
         client.send(:get, path: '/some/path')
       rescue Keratin::ClientError => response
-        assert_equal [{"field"=>"account", "message"=>"NOT_FOUND"}], response.errors
+        assert_equal({"account" => ["NOT_FOUND"]}, response.errors)
+        assert_equal '{"account"=>["NOT_FOUND"]}', response.to_s
       end
     end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,112 @@
+require_relative 'test_helper'
+
+class Keratin::ClientTest < Keratin::AuthN::TestCase
+  BASE = "https://example.service"
+  BASIC_AUTH = {basic_auth: ['hello', 'world']}
+
+  def client
+    @client ||= Keratin::Client.new(BASE, username: 'hello', password: 'world')
+  end
+
+  testing '#initialize' do
+    test 'normalizing path' do
+      assert_equal BASE, Keratin::Client.new(BASE).base
+      assert_equal BASE, Keratin::Client.new(BASE + '/').base
+    end
+  end
+
+  testing '#get' do
+    test 'with path' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(body: "{}")
+
+      client.send(:get, path: '/some/path')
+
+      assert_requested(stub)
+    end
+  end
+
+  testing '#patch' do
+    test 'with path' do
+      stub = stub_request(:patch, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(body: "{}")
+
+      client.send(:patch, path: '/some/path')
+
+      assert_requested(stub)
+    end
+  end
+
+  testing '#delete' do
+    test 'with path' do
+      stub = stub_request(:delete, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(body: "{}")
+
+      client.send(:delete, path: '/some/path')
+
+      assert_requested(stub)
+    end
+  end
+
+  testing 'response:' do
+    test '2xx' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(status: 200, body: '{"result": [1,2,3]}')
+
+      response = client.send(:get, path: '/some/path')
+      assert response.is_a?(Keratin::ServiceResult)
+      assert_equal [1, 2, 3], response.result
+    end
+
+    test '3xx' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(status: 302, headers: {'Location' => 'https://example.com'})
+
+      response = client.send(:get, path: '/some/path')
+      assert response.is_a?(Keratin::ServiceResult)
+      assert_equal 'https://example.com', response.result['location']
+    end
+
+    test '4xx' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(status: 404, body: '{"errors": [{"field": "account", "message": "NOT_FOUND"}]}')
+
+      begin
+        client.send(:get, path: '/some/path')
+      rescue Keratin::ClientError => response
+        assert_equal [{"field"=>"account", "message"=>"NOT_FOUND"}], response.errors
+      end
+    end
+
+    test '5xx' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_return(status: 500, body: "500 WHOOPS")
+
+      begin
+        client.send(:get, path: '/some/path')
+      rescue Keratin::ServiceError => response
+        assert_equal '500 WHOOPS', response.message
+      end
+    end
+
+    test 'timeout' do
+      stub = stub_request(:get, "#{BASE}/some/path")
+        .with(BASIC_AUTH)
+        .to_raise(Net::OpenTimeout.new('could not connect'))
+
+      begin
+        client.send(:get, path: '/some/path')
+      rescue Keratin::ServiceError => response
+        assert_equal 'could not connect', response.message
+      end
+
+    end
+  end
+end

--- a/test/keratin_authn_test.rb
+++ b/test/keratin_authn_test.rb
@@ -16,31 +16,31 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
     end
 
     test "with invalid JWT" do
-      assert_equal nil, Keratin::AuthN.subject_from(nil)
-      assert_equal nil, Keratin::AuthN.subject_from('')
-      assert_equal nil, Keratin::AuthN.subject_from('a')
-      assert_equal nil, Keratin::AuthN.subject_from('a.b')
-      assert_equal nil, Keratin::AuthN.subject_from('a.b.c')
+      assert_nil Keratin::AuthN.subject_from(nil)
+      assert_nil Keratin::AuthN.subject_from('')
+      assert_nil Keratin::AuthN.subject_from('a')
+      assert_nil Keratin::AuthN.subject_from('a.b')
+      assert_nil Keratin::AuthN.subject_from('a.b.c')
     end
 
     test "with unsigned JWT" do
       stub_auth_server
       jwt = JSON::JWT.new(claims)
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with JWT signed by unknown keypair" do
       stub_auth_server
       some_key = OpenSSL::PKey::RSA.new(512)
       jwt = JSON::JWT.new(claims).sign(some_key, 'RS256')
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with tampered JWT" do
       stub_auth_server
       jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
       jwt['sub'] = 999999
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with cached issuer keys" do
@@ -69,7 +69,7 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
       stub_auth_server(issuer: "https://evil.tech", keypair: evil_keypair)
 
       jwt = JSON::JWT.new(claims.merge(iss: 'https://evil.tech')).sign(evil_keypair, 'RS256')
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with valid JWT from same issuer with different formatting" do
@@ -81,12 +81,12 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
 
     test "with valid JWT for different audience" do
       jwt = JSON::JWT.new(claims.merge(aud: 'https://evil.tech')).sign(jws_keypair, 'RS256')
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with expired JWT" do
       jwt = JSON::JWT.new(claims.merge(exp: (Time.now - 1).to_i)).sign(jws_keypair, 'RS256')
-      assert_equal nil, Keratin::AuthN.subject_from(jwt.to_s)
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
   end
 


### PR DESCRIPTION
This adds support for private AuthN endpoints, requiring additional configuration for an HTTP Basic `username` and `password`.

Currently supported:

* `Keratin.authn.lock(account_id)`
* `Keratin.authn.unlock(account_id)`
* `Keratin.authn.archive(account_id)`

Successful actions will return a `Keratin::ServiceResult` with the JSON's `{"result": ...}` data.

Failed actions will raise a `Keratin::ClientError` with the JSON's `{"errors": ...}` data.