### PR TITLE
use jwt.kid to find correct signing key

### DIFF
--- a/lib/keratin/authn/id_token_verifier.rb
+++ b/lib/keratin/authn/id_token_verifier.rb
@@ -35,7 +35,7 @@ module Keratin::AuthN
     end
 
     def token_intact?
-      jwt.verify!(@keychain.getset(jwt['iss']){ Issuer.new(jwt['iss']).signing_key(jwt.kid) })
+      jwt.verify!(@keychain.getset(jwt.kid){ Issuer.new(jwt['iss']).signing_key(jwt.kid) })
     rescue JSON::JWT::VerificationFailed, JSON::JWT::UnexpectedAlgorithm
       false
     end

--- a/lib/keratin/authn/id_token_verifier.rb
+++ b/lib/keratin/authn/id_token_verifier.rb
@@ -35,7 +35,7 @@ module Keratin::AuthN
     end
 
     def token_intact?
-      jwt.verify!(@keychain.getset(jwt['iss']){ Issuer.new(jwt['iss']).signing_key })
+      jwt.verify!(@keychain.getset(jwt['iss']){ Issuer.new(jwt['iss']).signing_key(jwt.kid) })
     rescue JSON::JWT::VerificationFailed, JSON::JWT::UnexpectedAlgorithm
       false
     end

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -15,8 +15,8 @@ module Keratin::AuthN
       delete(path: "/accounts/:account_id").result
     end
 
-    def signing_key
-      keys.find{|k| k['use'] == 'sig' }
+    def signing_key(kid)
+      keys.find{|k| k['use'] == 'sig' && (kid.blank? || kid == k['kid']) }
     end
 
     def configuration

--- a/lib/keratin/authn/test/helpers.rb
+++ b/lib/keratin/authn/test/helpers.rb
@@ -13,7 +13,7 @@ module Keratin::AuthN
           sub: subject,
           iat: 10.seconds.ago,
           exp: 1.hour.from_now
-        ).sign(jws_keypair, JWS_ALGORITHM).to_s
+        ).sign(jws_keypair.to_jwk, JWS_ALGORITHM).to_s
       end
 
       # a temporary RSA key for our test suite.

--- a/test/keratin_authn_test.rb
+++ b/test/keratin_authn_test.rb
@@ -16,7 +16,7 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
   testing '.subject_from' do
     test "with valid JWT" do
       stub_auth_server
-      jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
       assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s)
     end
 
@@ -43,14 +43,14 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
 
     test "with tampered claims JWT" do
       stub_auth_server
-      jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
       jwt['sub'] = 999999
       assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with tampered alg=none JWT" do
       stub_auth_server
-      jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
       jwt.alg = 'none'
       jwt.signature = ''
       assert_nil Keratin::AuthN.subject_from(jwt.to_s)
@@ -68,7 +68,7 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
     test "with cached issuer keys" do
       Keratin::AuthN.keychain[Keratin::AuthN.config.issuer] = jws_keypair.to_jwk
 
-      jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
       assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s)
     end
 
@@ -79,7 +79,7 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
         Timecop.freeze(Time.now + Keratin::AuthN.config.keychain_ttl + 1)
 
         stub_auth_server
-        jwt = JSON::JWT.new(claims).sign(jws_keypair, 'RS256')
+        jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
         assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s)
       ensure
         Timecop.return
@@ -96,18 +96,18 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
 
     test "with valid JWT from same issuer with different formatting" do
       stub_auth_server
-      jwt = JSON::JWT.new(claims.merge(iss: Keratin::AuthN.config.issuer + '/')).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims.merge(iss: Keratin::AuthN.config.issuer + '/')).sign(jws_keypair.to_jwk, 'RS256')
       refute_equal jwt['iss'], Keratin::AuthN.config.issuer
       assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with valid JWT for different audience" do
-      jwt = JSON::JWT.new(claims.merge(aud: 'https://evil.tech')).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims.merge(aud: 'https://evil.tech')).sign(jws_keypair.to_jwk, 'RS256')
       assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
     test "with expired JWT" do
-      jwt = JSON::JWT.new(claims.merge(exp: (Time.now - 1).to_i)).sign(jws_keypair, 'RS256')
+      jwt = JSON::JWT.new(claims.merge(exp: (Time.now - 1).to_i)).sign(jws_keypair.to_jwk, 'RS256')
       assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
   end

--- a/test/keratin_authn_test.rb
+++ b/test/keratin_authn_test.rb
@@ -65,8 +65,8 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
       assert_nil Keratin::AuthN.subject_from(jwt.to_s)
     end
 
-    test "with cached issuer keys" do
-      Keratin::AuthN.keychain[Keratin::AuthN.config.issuer] = jws_keypair.to_jwk
+    test "with cached keys" do
+      Keratin::AuthN.keychain[jws_keypair.to_jwk[:kid]] = jws_keypair.to_jwk
 
       jwt = JSON::JWT.new(claims).sign(jws_keypair.to_jwk, 'RS256')
       assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s)


### PR DESCRIPTION
Compatibility with https://github.com/keratin/authn/pull/36.

Identity tokens include a `kid`. Use that to select the correct signing key from the issuer's JWK set. If no `kid` is present, pick any key and expect the token to not verify.