### PR TITLE
support for importing accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ logout functionality there as it can also take care of deleting the cookie.
 * `Keratin.authn.archive(account_id)`: will wipe all personal information, including username and
   password. Intended for user deletion routine.
 
+### Other
+
+* `Keratin.authn.import(username: user.email, password: user.password, locked: false)`: will create
+  an account in Keratin. Intended for importing data from a legacy system. Returns an `account_id`,
+  or raises on validation errors.
+
 ### Example: Sessions
 
 You should store the token in a cookie (the [keratin/authn-js](https://github.com/keratin/authn-js)

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -15,6 +15,15 @@ module Keratin::AuthN
       delete(path: "/accounts/#{account_id}").result
     end
 
+    # returns account_id or raises exception
+    def import(username:, password:, locked: false)
+      post(path: '/accounts/import', body: {
+        username: username,
+        password: password,
+        locked: locked
+      }).result['id']
+    end
+
     def signing_key(kid)
       keys.find{|k| k['use'] == 'sig' && (kid.blank? || kid == k['kid']) }
     end

--- a/lib/keratin/client.rb
+++ b/lib/keratin/client.rb
@@ -39,6 +39,10 @@ module Keratin
       submit(Net::HTTP::Get, **opts)
     end
 
+    private def post(**opts)
+      submit(Net::HTTP::Post, **opts)
+    end
+
     private def patch(**opts)
       submit(Net::HTTP::Patch, **opts)
     end
@@ -47,11 +51,12 @@ module Keratin
       submit(Net::HTTP::Delete, **opts)
     end
 
-    private def submit(request_klass, path:)
+    private def submit(request_klass, path:, body: nil)
       uri = URI.parse("#{base}#{path}")
 
       request = request_klass.new(uri)
       request.basic_auth(*@auth) if @auth
+      request.set_form_data(body) if body
 
       Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         http.open_timeout = 0.5

--- a/test/issuer_test.rb
+++ b/test/issuer_test.rb
@@ -27,6 +27,20 @@ class Keratin::IssuerTest < Keratin::AuthN::TestCase
     assert_requested(stub)
   end
 
+  testing '#import' do
+    test 'success' do
+      stub_request(:post, 'https://issuer.tech/accounts/import').to_return(body: '{"result":{"id":123}}')
+      assert_equal 123, subject.import(username: 'username', password: 'password')
+    end
+
+    test 'failure' do
+      stub_request(:post, 'https://issuer.tech/accounts/import').to_return(status: 422, body: '{"errors": [{"field":"username","message":"MISSING"}]}')
+      assert_raises Keratin::Error do
+        subject.import(username: 'username', password: 'password')
+      end
+    end
+  end
+
   testing '#signing_key' do
     test 'with multiple keys' do
       stub_request(:get, 'https://issuer.tech/configuration').to_return(body: {'jwks_uri' => 'https://issuer.tech/jwks'}.to_json)


### PR DESCRIPTION
Adds support for https://github.com/keratin/authn/pull/41. Invoking `Keratin.authn.import()` will attempt to create an account on the AuthN server, returning the account's id.