### PR TITLE
support for flagging an account for a password change

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ logout functionality there as it can also take care of deleting the cookie.
 * `Keratin.authn.unlock(account_id)`: will unlock an account, restoring normal functionality.
 * `Keratin.authn.archive(account_id)`: will wipe all personal information, including username and
   password. Intended for user deletion routine.
+* `Keratin.authn.expire_password(account_id)`: will force the account to reset their password on the
+  next login, and revoke all current sessions. Intended for use when password is deemed insecure or
+  otherwise expired.
 
 ### Other
 

--- a/lib/keratin/authn/issuer.rb
+++ b/lib/keratin/authn/issuer.rb
@@ -24,6 +24,10 @@ module Keratin::AuthN
       }).result['id']
     end
 
+    def expire_password(account_id)
+      patch(path: "/accounts/#{account_id}/expire_password")
+    end
+
     def signing_key(kid)
       keys.find{|k| k['use'] == 'sig' && (kid.blank? || kid == k['kid']) }
     end

--- a/test/issuer_test.rb
+++ b/test/issuer_test.rb
@@ -41,6 +41,14 @@ class Keratin::IssuerTest < Keratin::AuthN::TestCase
     end
   end
 
+  testing '#expire_password' do
+    test 'success' do
+      stub = stub_request(:patch, 'https://issuer.tech/accounts/123/expire_password').to_return(body: '{}')
+      subject.expire_password(123)
+      assert_requested(stub)
+    end
+  end
+
   testing '#signing_key' do
     test 'with multiple keys' do
       stub_request(:get, 'https://issuer.tech/configuration').to_return(body: {'jwks_uri' => 'https://issuer.tech/jwks'}.to_json)


### PR DESCRIPTION
Support for [AuthN PR #42](https://github.com/keratin/authn/pull/42), which adds an endpoint for flagging an account to require an immediate password change.