### PR TITLE
Added an optional parameter to subject_from

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ class SessionsController
 end
 ```
 
+### Example: Multiple Domains
+
+When working with multiple frontend domains it may be beneficial to use a referrer header as your audience instead of a static configuration. You can do this by providing an additional parameter to the `subject_from` method.
+
+```ruby
+class ApplicationController
+  private
+
+  def current_user
+    return @current_user if defined? @current_user
+    @current_user = User.find_by_account_id(current_account_id)
+  end
+
+  def current_account_id
+    Keratin::AuthN.subject_from(cookies[:authn], audience: URI.parse(request.referer).host)
+  end
+end
+```
+
 ## Testing Your App
 
 AuthN provides helpers for working with tokens in your application's controller and integration tests.
@@ -138,4 +157,3 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/keratin/authn-rb. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-

--- a/lib/keratin/authn.rb
+++ b/lib/keratin/authn.rb
@@ -73,8 +73,8 @@ module Keratin
     class << self
       # safely fetches a subject from the id token after checking relevant claims and
       # verifying the signature.
-      def subject_from(id_token)
-        verifier = IDTokenVerifier.new(id_token, signature_verifier)
+      def subject_from(id_token, audience: Keratin::AuthN.config.audience)
+        verifier = IDTokenVerifier.new(id_token, signature_verifier, audience)
         verifier.subject if verifier.verified?
       end
 

--- a/lib/keratin/authn/id_token_verifier.rb
+++ b/lib/keratin/authn/id_token_verifier.rb
@@ -2,9 +2,10 @@ require 'uri'
 
 module Keratin::AuthN
   class IDTokenVerifier
-    def initialize(str, signature_verifier)
+    def initialize(str, signature_verifier, audience)
       @id_token = str
       @signature_verifier = signature_verifier
+      @audience = audience
       @time = Time.now.to_i
     end
 
@@ -42,7 +43,7 @@ module Keratin::AuthN
     end
 
     def token_for_us?
-      jwt[:aud] == Keratin::AuthN.config.audience
+      jwt[:aud] == @audience
     end
 
     def token_fresh?

--- a/test/keratin_authn_test.rb
+++ b/test/keratin_authn_test.rb
@@ -112,6 +112,21 @@ class Keratin::AuthNTest < Keratin::AuthN::TestCase
     end
   end
 
+  testing '.subject_from.audience' do
+    test 'with a matching audience' do
+      stub_auth_server
+      audience = 'another.tech'
+      jwt = JSON::JWT.new(claims.merge(aud: audience)).sign(jws_keypair.to_jwk, 'RS256')
+      assert_equal jwt['sub'], Keratin::AuthN.subject_from(jwt.to_s, audience: audience)
+    end
+
+    test 'without a matching audience' do
+      stub_auth_server
+      jwt = JSON::JWT.new(claims.merge(aud: 'first.tech')).sign(jws_keypair.to_jwk, 'RS256')
+      assert_nil Keratin::AuthN.subject_from(jwt.to_s, audience: 'second.tech')
+    end
+  end
+
   testing '.logout_url' do
     test 'with a next url' do
       assert_equal 'https://issuer.tech/sessions/logout?redirect_uri=https%3A%2F%2Fapp.tech', Keratin::AuthN.logout_url(return_to: 'https://app.tech')


### PR DESCRIPTION
This allows you to use multiple frontend domains with the same backend and still have strong audience verification if you use the referer header.

Fixes #7 