### PR TITLE
support for divided public/private networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Keratin::AuthN.config.tap do |config|
   # HTTP basic auth for using AuthN's private endpoints
   config.username = 'secret'
   config.password = 'secret'
+
+  # OPTIONAL: enables debugging for the JWT verification process
+  config.logger   = Rails.logger
+
+  # OPTIONAL: allows private API calls to use private network routing
+  config.authn_url = 'https://authn.internal.dns/
 end
 ```
 

--- a/lib/keratin/authn.rb
+++ b/lib/keratin/authn.rb
@@ -11,7 +11,7 @@ require 'json/jwt'
 module Keratin
   def self.authn
     @authn ||= AuthN::API.new(
-      AuthN.config.issuer,
+      AuthN.config.authn_url || AuthN.config.issuer,
       username: AuthN.config.username,
       password: AuthN.config.password
     )
@@ -26,6 +26,11 @@ module Keratin
       # the base url of the service handling authentication
       # e.g. "https://issuer.tech"
       attr_accessor :issuer
+
+      # the base url for API calls. this is useful if you've divided your network so private API
+      # requests can not be probed by public devices. it is optional, and will default to issuer.
+      # e.g. "https://authn.internal.dns"
+      attr_accessor :authn_url
 
       # how long (in seconds) to keep keys in the keychain before refreshing.
       # default: 3600


### PR DESCRIPTION
This allows a deployment to firewall the private APIs away from the public realm. JWKs will still be fetched from the public realm, but anything involving HTTP basic auth can use private networking.

Fixes #10 